### PR TITLE
Add send_http action

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ will recursively (including subdirectories) load all the YAML files. For example
   ## Actions:
   ##   Actions are a series of functions to run, which defines the
   ##   behaviors of the mock. Availabe actions are:
-  ##     - sleep
-  ##     - set_data
-  ##     - reply_http
-  ##     - publish_kafka
   ##     - publish_amqp
-  ##     - publish_webhook
+  ##     - publish_kafka
+  ##     - redis
+  ##     - reply_http
+  ##     - send_http
+  ##     - sleep
   ####################################################################
   actions:
     - publish_kafka:
@@ -268,7 +268,7 @@ OpenMock leverages [https://golang.org/pkg/text/template/](https://golang.org/pk
         payload_from_file: './files/colors.json'
 ```
 
-### Example: using redis (by default, it uses an in-memory miniredis)
+### Example: Using Redis (by default, it uses an in-memory miniredis)
 ```
 # demo_templates/redis.yaml
 
@@ -303,6 +303,30 @@ OpenMock leverages [https://golang.org/pkg/text/template/](https://golang.org/pk
 
 # To test
 # curl localhost:9999/test_redis -H "X-TOKEN:t123"  | jq .
+```
+
+### Example: Send Webhooks
+```
+# demo_templates/webhook.yaml
+
+- key: webhooks
+  expect:
+    http:
+      method: GET
+      path: /send_webhook_to_httpbin
+  actions:
+    - send_http:
+        url: "https://httpbin.org/post"
+        method: POST
+        body: '{"hello": "world"}'
+        headers:
+          X-Token: t123
+    - reply_http:
+        status_code: 200
+        body: 'webhooks sent'
+
+# To test
+# curl localhost:9999/send_webhook_to_httpbin
 ```
 
 # Advanced pipeline functions

--- a/demo_templates/webhook.yaml
+++ b/demo_templates/webhook.yaml
@@ -1,0 +1,15 @@
+- key: webhooks
+  expect:
+    http:
+      method: GET
+      path: /send_webhook_to_httpbin
+  actions:
+    - send_http:
+        url: "https://httpbin.org/post"
+        method: POST
+        body: '{"hello": "world"}'
+        headers:
+          X-Token: t123
+    - reply_http:
+        status_code: 200
+        body: 'webhooks sent'

--- a/model.go
+++ b/model.go
@@ -60,27 +60,27 @@ type (
 
 // Action represents actions
 type Action struct {
-	ActionSleep        ActionSleep        `yaml:"sleep"`
-	ActionRedis        ActionRedis        `yaml:"redis"`
-	ActionPublishKafka ActionPublishKafka `yaml:"publish_kafka"`
 	ActionPublishAMQP  ActionPublishAMQP  `yaml:"publish_amqp"`
-	ActionSendWebhook  ActionSendWebhook  `yaml:"send_webhook"`
+	ActionPublishKafka ActionPublishKafka `yaml:"publish_kafka"`
+	ActionRedis        ActionRedis        `yaml:"redis"`
 	ActionReplyHTTP    ActionReplyHTTP    `yaml:"reply_http"`
+	ActionSendHTTP     ActionSendHTTP     `yaml:"send_http"`
+	ActionSleep        ActionSleep        `yaml:"sleep"`
 }
 
 // ActionRedis represents a list of redis commands
 type ActionRedis []string
 
-// ActionSendWebhook represents the webhook return
-type ActionSendWebhook struct {
+// ActionSendHTTP represents the send http action
+type ActionSendHTTP struct {
 	URL          string            `yaml:"url"`
-	StatusCode   int               `yaml:"status_code"`
+	Method       string            `yaml:"method"`
 	Headers      map[string]string `yaml:"headers"`
 	Body         string            `yaml:"body"`
 	BodyFromFile string            `yaml:"body_from_file"`
 }
 
-// ActionReplyHTTP represents http return
+// ActionReplyHTTP represents reply http action
 type ActionReplyHTTP struct {
 	StatusCode   int               `yaml:"status_code"`
 	Headers      map[string]string `yaml:"headers"`
@@ -88,7 +88,7 @@ type ActionReplyHTTP struct {
 	BodyFromFile string            `yaml:"body_from_file"`
 }
 
-// ActionPublishAMQP represents AMQP return
+// ActionPublishAMQP represents publish AMQP action
 type ActionPublishAMQP struct {
 	Exchange        string `yaml:"exchange"`
 	RoutingKey      string `yaml:"routing_key"`
@@ -96,7 +96,7 @@ type ActionPublishAMQP struct {
 	PayloadFromFile string `yaml:"payload_from_file"`
 }
 
-// ActionPublishKafka represents kafka return
+// ActionPublishKafka represents publish kafka action
 type ActionPublishKafka struct {
 	Topic           string `yaml:"topic"`
 	Payload         string `yaml:"payload"`


### PR DESCRIPTION
Adding the feature of sending webhooks.

Example of the yaml:

```
- key: webhooks
  expect:
    http:
      method: GET
      path: /send_webhook_to_httpbin
  actions:
    - send_http:
        url: "https://httpbin.org/post"
        method: POST
        body: '{"hello": "world"}'
        headers:
          X-Token: t123
    - reply_http:
        status_code: 200
        body: 'webhooks sent'
```