### PR TITLE
Fix amqp reconnection

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -1,15 +1,8 @@
 package openmock
 
 import (
-	"sync"
-
 	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
-)
-
-var (
-	amqpOnce    sync.Once
-	amqpChannel *amqp.Channel
 )
 
 const rabbitContentType = "application/octet-stream"
@@ -26,7 +19,9 @@ func publishToAMQP(amqpURL string, exchange string, routingKey string, payload s
 		}).Info("try to publish to amqp")
 	}()
 
-	ch := getAMQPChannel(amqpURL)
+	ch, cleanUp := newAMQPChannel(amqpURL)
+	defer cleanUp()
+
 	if err := prepareChannel(ch, exchange, routingKey, ""); err != nil {
 		logrus.Errorf("%s: %s", "failed to prepare the channel for amqp", err)
 		return
@@ -47,59 +42,70 @@ func publishToAMQP(amqpURL string, exchange string, routingKey string, payload s
 	}
 }
 
-func getAMQPChannel(amqpURL string) *amqp.Channel {
-	amqpOnce.Do(func() {
-		conn, err := amqp.Dial(amqpURL)
-		if err != nil {
-			logrus.Fatalf("%s: %s", "failed to connect ot AMQP", err)
-		}
+func newAMQPChannel(amqpURL string) (ch *amqp.Channel, cleanUp func()) {
+	conn, err := amqp.Dial(amqpURL)
+	if err != nil {
+		logrus.Fatalf("%s: %s", "failed to connect ot AMQP", err)
+	}
 
-		ch, err := conn.Channel()
-		if err != nil {
-			logrus.Fatalf("%s: %s", "failed to open a channel", err)
-		}
-		amqpChannel = ch
-	})
-	return amqpChannel
+	ch, err = conn.Channel()
+	if err != nil {
+		logrus.Fatalf("%s: %s", "failed to open a channel", err)
+	}
+
+	cleanUp = func() {
+		ch.Close()
+		conn.Close()
+	}
+	return ch, cleanUp
 }
 
 func (om *OpenMock) startAMQP() {
 	mocks := om.repo.AMQPMocks
 	for amqp, ms := range mocks {
-		func(amqp ExpectAMQP, ms MocksArray) {
-			ch := getAMQPChannel(om.AMQPURL)
-			if err := prepareChannel(ch, amqp.Exchange, amqp.RoutingKey, amqp.Queue); err != nil {
-				logrus.Errorf("%s: %s", "failed to prepare the channel for amqp", err)
-				return
-			}
+		go startWorker(om, amqp, ms)
+	}
+}
 
-			msgs, err := ch.Consume(
-				amqp.Queue, // queue
-				"",         // consumer unique name, if "", it will be randomly generated
-				true,       // auto-ack
-				false,      // exclusive
-				false,      // no-local
-				false,      // no-wait
-				nil,        // args
-			)
-			if err != nil {
-				logrus.Errorf("%s: %s", "failed to consume from a queue", err)
-				return
-			}
-			go func() {
-				for msg := range msgs {
-					logrus.WithFields(logrus.Fields{
-						"amqp_msg":    string(msg.Body),
-						"exchange":    msg.Exchange,
-						"routing_key": msg.RoutingKey,
-					}).Info()
-					ms.DoActions(&Context{
-						AMQPPayload: string(msg.Body),
-						om:          om,
-					})
-				}
-			}()
-		}(amqp, ms)
+func startWorker(om *OpenMock, amqp ExpectAMQP, ms MocksArray) {
+	// use a for loop here to reconnect on failures
+	for {
+		logrus.WithFields(logrus.Fields{"queue": amqp.Queue}).Info("amqp worker started")
+
+		ch, cleanUp := newAMQPChannel(om.AMQPURL)
+
+		if err := prepareChannel(ch, amqp.Exchange, amqp.RoutingKey, amqp.Queue); err != nil {
+			logrus.Errorf("%s: %s", "failed to prepare the channel for amqp", err)
+			return
+		}
+
+		msgs, err := ch.Consume(
+			amqp.Queue, // queue
+			"",         // consumer unique name, if "", it will be randomly generated
+			true,       // auto-ack
+			false,      // exclusive
+			false,      // no-local
+			false,      // no-wait
+			nil,        // args
+		)
+		if err != nil {
+			logrus.Errorf("%s: %s", "failed to consume from a queue", err)
+			return
+		}
+		for msg := range msgs {
+			logrus.WithFields(logrus.Fields{
+				"amqp_msg":    string(msg.Body),
+				"exchange":    msg.Exchange,
+				"routing_key": msg.RoutingKey,
+			}).Info()
+			ms.DoActions(&Context{
+				AMQPPayload: string(msg.Body),
+				om:          om,
+			})
+		}
+
+		logrus.WithFields(logrus.Fields{"queue": amqp.Queue}).Warn("amqp worker connection reset")
+		cleanUp()
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:3.6.6-management
-    container_name: openmock-zookeeper
+    container_name: openmock-rabbitmq
     ports:
       - 4369:4369
       - 5671-5672:5671-5672

--- a/redis.go
+++ b/redis.go
@@ -55,7 +55,7 @@ func (om *OpenMock) SetRedis() {
 	default:
 		s, err := miniredis.Run()
 		if err != nil {
-			logrus.Fatalf("cannot create miniredis", om.RedisURL, err)
+			logrus.Fatalf("cannot create miniredis. url:%s, err:%s", om.RedisURL, err)
 		}
 		om.redis = NewRedisDoer(fmt.Sprintf("redis://%s:%s", s.Host(), s.Port()))
 	}


### PR DESCRIPTION
Any network or server-side connection failures will stop the amqp's worker. This pr adds reconnection to fix the issue.