### PR TITLE
Add soap example

### DIFF
--- a/demo_templates/http.yaml
+++ b/demo_templates/http.yaml
@@ -75,3 +75,27 @@
                 </note>
               ` | htmlEscapeString }}
           </xml>
+
+
+- key: soap_example
+  expect:
+    http:
+      method: POST
+      path: /soap_example
+  actions:
+    - reply_http:
+        status_code: 200
+        headers:
+          Content-Type: "text/xml; charset = utf-8"
+        body: >
+          <?xml version = "1.0"?>
+          <SOAP-ENV:Envelope
+             xmlns:SOAP-ENV = "http://www.w3.org/2001/12/soap-envelope"
+             SOAP-ENV:encodingStyle = "http://www.w3.org/2001/12/soap-encoding">
+
+             <SOAP-ENV:Body xmlns:m = "http://www.xyz.org/quotation">
+                <m:GetQuotationResponse>
+                   <m:Quotation>Here is the quotation</m:Quotation>
+                </m:GetQuotationResponse>
+             </SOAP-ENV:Body>
+          </SOAP-ENV:Envelope>


### PR DESCRIPTION
Tested with curl.

```
curl -v -XPOST localhost:9999/soap_example

*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9999 (#0)
> POST /soap_example HTTP/1.1
> Host: localhost:9999
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/xml; charset = utf-8
< Date: Thu, 16 May 2019 21:46:00 GMT
< Content-Length: 399
<
* Connection #0 to host localhost left intact
<?xml version = "1.0"?> <SOAP-ENV:Envelope    xmlns:SOAP-ENV = "http://www.w3.org/2001/12/soap-envelope"    SOAP-ENV:encodingStyle = "http://www.w3.org/2001/12/soap-encoding">     <SOAP-ENV:Body xmlns:m = "http://www.xyz.org/quotation">       <m:GetQuotationResponse>          <m:Quotation>Here is the quotation</m:Quotation>       </m:GetQuotationResponse>    </SOAP-ENV:Body> </SOAP-ENV:Envelope>
```