### PR TITLE
Prepare for components

### DIFF
--- a/template.go
+++ b/template.go
@@ -30,6 +30,8 @@ type Context struct {
 	om *OpenMock
 }
 
+var globalTemplate = template.New("__global__")
+
 // cleanup replaces all the linebreaks and tabs with spaces
 func cleanup(raw string) string {
 	re := regexp.MustCompile(`\r?\n|\t`)
@@ -38,7 +40,7 @@ func cleanup(raw string) string {
 
 // Render renders the raw given the context
 func (c *Context) Render(raw string) (out string, err error) {
-	tmpl, err := template.New("").
+	tmpl, err := globalTemplate.New("").
 		Funcs(sprig.TxtFuncMap()). // supported functions https://github.com/Masterminds/sprig/blob/master/functions.go
 		Funcs(genLocalFuncMap(c.om)).
 		Parse(cleanup(raw))

--- a/template_test.go
+++ b/template_test.go
@@ -96,6 +96,35 @@ func TestTemplateRender(t *testing.T) {
 			}
 		`)
 	})
+
+	t.Run("temp templates defined in templates", func(t *testing.T) {
+		raw := `
+{{define "T1"}}ONE{{end}}
+{{define "T2"}}TWO{{end}}
+{{define "T3"}}{{template "T1"}} {{template "T2"}}{{end}}
+{{template "T3"}}
+`
+		c := &Context{}
+		r, err := c.Render(raw)
+		assert.NoError(t, err)
+		assert.Equal(t, r, `    ONE TWO `)
+	})
+
+	t.Run("predefined templates reused in other templates", func(t *testing.T) {
+		t1 := `{{define "T1"}}T1{{end}}`
+		t2 := `{{define "T2"}}T2{{end}}`
+		t3 := `{{template "T1"}}{{template "T2"}}`
+
+		c := &Context{}
+		var err error
+		_, err = c.Render(t1)
+		assert.NoError(t, err)
+		_, err = c.Render(t2)
+		assert.NoError(t, err)
+		r, err := c.Render(t3)
+		assert.NoError(t, err)
+		assert.Equal(t, r, `T1T2`)
+	})
 }
 
 func TestRenderConditions(t *testing.T) {


### PR DESCRIPTION
This pr extracts the template instance to be global so that templates can reference each other. We are going to leverage `{{define ...}}{{end}}` syntax from https://golang.org/pkg/text/template/#hdr-Nested_template_definitions.

The idea of components will be similar to the "predefined templates reused in other templates" test. We can render the components first (will be implemented in the next PRs) and then use `{{template ...}}` to reuse the components.
