### PR TITLE
Add template reuse and kinds

### DIFF
--- a/demo_templates/http.yaml
+++ b/demo_templates/http.yaml
@@ -110,3 +110,21 @@
                 </m:GetQuotationResponse>
              </SOAP-ENV:Body>
           </SOAP-ENV:Envelope>
+
+
+- key: my_template_1
+  kind: Template
+  template: >
+    { "foo": "bar", "name": "my_template_1", "http_path": "{{.HTTPPath}}" }
+
+
+- key: get_with_template
+  expect:
+    http:
+      method: GET
+      path: /get_with_template
+  actions:
+    - reply_http:
+        status_code: 200
+        body: >
+          {{template "my_template_1" .}}

--- a/load_test.go
+++ b/load_test.go
@@ -83,6 +83,7 @@ func TestLoad(t *testing.T) {
 		om := &OpenMock{
 			TemplatesDir: "demo_templates",
 		}
+		om.setupRepo()
 		err := om.Load()
 		assert.NoError(t, err)
 		assert.NotZero(t, len(om.repo.AMQPMocks))

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,96 @@
+package openmock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelValidate(t *testing.T) {
+
+	t.Run("invalid empty", func(t *testing.T) {
+		m := &Mock{}
+		assert.Error(t, m.Validate())
+	})
+
+	t.Run("valid KindTemplate", func(t *testing.T) {
+		m := &Mock{
+			Kind:     KindTemplate,
+			Key:      "t1",
+			Template: "t1",
+		}
+		assert.NoError(t, m.Validate())
+	})
+
+	t.Run("invalid KindTemplate - template cannot have non-empty expect", func(t *testing.T) {
+		m := &Mock{
+			Kind:     KindTemplate,
+			Key:      "t1",
+			Template: "t1",
+			Expect: Expect{
+				HTTP: ExpectHTTP{
+					Path: "/t1",
+				},
+			},
+		}
+		assert.Error(t, m.Validate())
+	})
+
+	t.Run("invalid KindTemplate - template cannot have non-empty actions", func(t *testing.T) {
+		m := &Mock{
+			Kind:     KindTemplate,
+			Key:      "t1",
+			Template: "t1",
+			Actions: []Action{
+				{
+					ActionSleep: ActionSleep{Duration: time.Second},
+				},
+			},
+		}
+		assert.Error(t, m.Validate())
+	})
+
+	t.Run("valid KindBehavior", func(t *testing.T) {
+		m := &Mock{
+			Key: "t1",
+			Expect: Expect{
+				HTTP: ExpectHTTP{
+					Path: "/t1",
+				},
+			},
+			Actions: []Action{
+				{
+					ActionSleep: ActionSleep{Duration: time.Second},
+				},
+			},
+		}
+		assert.NoError(t, m.Validate())
+	})
+
+	t.Run("invalid KindBehavior - behavior cannot have template field", func(t *testing.T) {
+		m := &Mock{
+			Key:      "t1",
+			Template: "t1",
+			Expect: Expect{
+				HTTP: ExpectHTTP{
+					Path: "/t1",
+				},
+			},
+			Actions: []Action{
+				{
+					ActionSleep: ActionSleep{Duration: time.Second},
+				},
+			},
+		}
+		assert.Error(t, m.Validate())
+	})
+
+	t.Run("invalid Kind", func(t *testing.T) {
+		m := &Mock{
+			Kind: "invalid",
+			Key:  "t1",
+		}
+		assert.Error(t, m.Validate())
+	})
+}

--- a/openmock.go
+++ b/openmock.go
@@ -51,9 +51,20 @@ func (om *OpenMock) setupLogrus() {
 	logrus.SetOutput(os.Stdout)
 }
 
+func (om *OpenMock) setupRepo() {
+	om.repo = &MockRepo{
+		HTTPMocks:  HTTPMocks{},
+		KafkaMocks: KafkaMocks{},
+		AMQPMocks:  AMQPMocks{},
+		Templates:  MocksArray{},
+	}
+}
+
 // Start starts the openmock
 func (om *OpenMock) Start() {
 	om.setupLogrus()
+	om.setupRepo()
+
 	om.SetRedis()
 	om.StartAdmin()
 


### PR DESCRIPTION
- Add Kind in the YAML block
- Add very basic `Validate` function for the YAML blocks
- Define `Template` with `kind: Template` and `template: ...`

Tested locally.

```
curl localhost:9999/get_with_template

{ "foo": "bar", "name": "my_template_1", "http_path": "/get_with_template" } 
```