### PR TITLE
Add basicauth example

### DIFF
--- a/demo_templates/http.yaml
+++ b/demo_templates/http.yaml
@@ -48,7 +48,7 @@
         status_code: 200
         body: '{{.HTTPQueryString}}'
 
-- key: header-token
+- key: header-token-200
   kind: Behavior
   expect:
     condition: '{{.HTTPHeader.Get "X-Token" | eq "t1234" | and (.HTTPHeader.Get "Y-Token" | eq "t1234")}}'
@@ -60,7 +60,7 @@
         status_code: 200
         body: OK
 
-- key: header-token
+- key: header-token-401
   kind: Behavior
   expect:
     condition: '{{.HTTPHeader.Get "X-Token" | ne "t1234"}}'

--- a/demo_templates/webhook.yaml
+++ b/demo_templates/webhook.yaml
@@ -14,3 +14,17 @@
     - reply_http:
         status_code: 200
         body: 'webhooks sent'
+
+- key: webhooks_with_basicauth
+  kind: Behavior
+  expect:
+    http:
+      method: GET
+      path: /send_webhook_to_httpbin_with_basicauth
+  actions:
+    - send_http:
+        url: 'https://{{env "USER"}}:{{env "PASSWORD"}}@httpbin.org/basic-auth/user1/password1'
+        method: GET
+    - reply_http:
+        status_code: 200
+        body: 'webhooks sent'


### PR DESCRIPTION
Tested locally. Sent a webhook to https://user1:password1@httpbin.org/basic-auth/user1/password1

```
$ make build
$ USER=user1 PASSWORD=password1 make run

[http] 2019/08/21 11:26:57 HTTP Request: GET /basic-auth/user1/password1 HTTP/1.1          
Host: httpbin.org                                                                          
                                                                                           
[http] 2019/08/21 11:26:57 HTTP Response: HTTP/1.1 200 OK                                 
Connection: close
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Wed, 21 Aug 2019 18:27:00 GMT
Referrer-Policy: no-referrer-when-downgrade
Server: nginx
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Xss-Protection: 1; mode=block

{
  "authenticated": true,
  "user": "user1"
}

```