### PR TITLE
Add linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  unittest:
     docker:
       - image: circleci/golang:1.12
     working_directory: /go/src/github.com/checkr/openmock
@@ -10,6 +10,6 @@ jobs:
 
 workflows:
   version: 2
-  build_and_docker_push:
+  test:
     jobs:
-      - build
+      - unittest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+linters:
+  enable:
+    - megacheck
+    - govet
+    - golint
+  disable:
+    - maligned
+  presets:
+    - bugs
+    - complexity
+    - format
+    - performance

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+GOLANGCILINT := $(shell command -v golangci-lint 2> /dev/null)
+
 .PHONY: vendor
 vendor:
 	@GO111MODULE=on go mod tidy
@@ -6,8 +8,15 @@ vendor:
 build:
 	@GO111MODULE=on go build -mod=vendor -o $(PWD)/om github.com/checkr/openmock/cmd/om
 
-test:
+test: lint
 	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic .
 
 run: build
 	OPENMOCK_TEMPLATES_DIR=./demo_templates ./om
+
+lint:
+ifndef GOLANGCILINT
+	@GO111MODULE=off go get -u github.com/myitcv/gobin
+	@gobin github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+endif
+	@golangci-lint run

--- a/admin.go
+++ b/admin.go
@@ -30,7 +30,12 @@ func (om *OpenMock) StartAdmin() {
 		defer body.Close()
 
 		buf := &bytes.Buffer{}
-		buf.ReadFrom(body)
+
+		_, err := buf.ReadFrom(body)
+		if err != nil {
+			return err
+		}
+
 		b := buf.Bytes()
 
 		mocks := []*Mock{}
@@ -40,7 +45,10 @@ func (om *OpenMock) StartAdmin() {
 
 		for _, mock := range mocks {
 			s, _ := yaml.Marshal([]*Mock{mock})
-			om.redis.Do("HSET", redisTemplatesStore, mock.Key, s)
+			_, err := om.redis.Do("HSET", redisTemplatesStore, mock.Key, s)
+			if err != nil {
+				return err
+			}
 		}
 
 		time.AfterFunc(reloadDelay, func() { reload.Exec() })

--- a/amqp.go
+++ b/amqp.go
@@ -93,15 +93,16 @@ func startWorker(om *OpenMock, amqp ExpectAMQP, ms MocksArray) {
 			return
 		}
 		for msg := range msgs {
+			err := ms.DoActions(Context{
+				AMQPPayload: string(msg.Body),
+				om:          om,
+			})
 			logrus.WithFields(logrus.Fields{
 				"amqp_msg":    string(msg.Body),
 				"exchange":    msg.Exchange,
 				"routing_key": msg.RoutingKey,
+				"err":         err,
 			}).Info()
-			ms.DoActions(Context{
-				AMQPPayload: string(msg.Body),
-				om:          om,
-			})
 		}
 
 		logrus.WithFields(logrus.Fields{"queue": amqp.Queue}).Warn("amqp worker connection reset")

--- a/cmd/om/main.go
+++ b/cmd/om/main.go
@@ -7,5 +7,7 @@ import (
 func main() {
 	om := &openmock.OpenMock{}
 	om.ParseEnv()
+
+	defer om.Stop()
 	om.Start()
 }

--- a/handle_actions_test.go
+++ b/handle_actions_test.go
@@ -12,16 +12,16 @@ type FakePerformer struct {
 	Performed       bool
 }
 
-func (self *FakePerformer) Perform(context Context) error {
-	self.Performed = true
-	self.ReceivedContext = context
+func (fp *FakePerformer) Perform(context Context) error {
+	fp.Performed = true
+	fp.ReceivedContext = context
 	return nil
 }
 
 func TestContextUpdate(t *testing.T) {
 	t.Run("update context for performing action", func(t *testing.T) {
 		mock := Mock{
-			Actions: []ActionDispatcher{ActionDispatcher{}},
+			Actions: []ActionDispatcher{{}},
 			Values: map[string]interface{}{
 				"foo": "bar",
 			},
@@ -29,8 +29,9 @@ func TestContextUpdate(t *testing.T) {
 
 		fakePerformer := FakePerformer{}
 		defer gostub.StubFunc(&getActualAction, &fakePerformer).Reset()
-		mock.DoActions(Context{})
 
+		err := mock.DoActions(Context{})
+		assert.NoError(t, err)
 		assert.Equal(t, "bar", fakePerformer.ReceivedContext.Values["foo"])
 	})
 
@@ -39,7 +40,7 @@ func TestContextUpdate(t *testing.T) {
 			Expect: Expect{
 				Condition: "{{.Values.perform}}",
 			},
-			Actions: []ActionDispatcher{ActionDispatcher{}},
+			Actions: []ActionDispatcher{{}},
 			Values: map[string]interface{}{
 				"perform": false,
 			},
@@ -47,8 +48,9 @@ func TestContextUpdate(t *testing.T) {
 
 		fakePerformer := FakePerformer{}
 		defer gostub.StubFunc(&getActualAction, &fakePerformer).Reset()
-		unActingMock.DoActions(Context{})
 
+		err := unActingMock.DoActions(Context{})
+		assert.NoError(t, err)
 		assert.False(t, fakePerformer.Performed)
 	})
 
@@ -57,7 +59,7 @@ func TestContextUpdate(t *testing.T) {
 			Expect: Expect{
 				Condition: "{{.Values.perform}}",
 			},
-			Actions: []ActionDispatcher{ActionDispatcher{}},
+			Actions: []ActionDispatcher{{}},
 			Values: map[string]interface{}{
 				"perform": true,
 			},
@@ -65,8 +67,9 @@ func TestContextUpdate(t *testing.T) {
 
 		fakePerformer := FakePerformer{}
 		defer gostub.StubFunc(&getActualAction, &fakePerformer).Reset()
-		actingMock.DoActions(Context{})
 
+		err := actingMock.DoActions(Context{})
+		assert.NoError(t, err)
 		assert.True(t, fakePerformer.Performed)
 	})
 }

--- a/kafka.go
+++ b/kafka.go
@@ -53,6 +53,10 @@ func (kc *kafkaClient) sendMessage(topic string, bytes []byte) (err error) {
 }
 
 func (kc *kafkaClient) close() error {
+	if kc == nil {
+		return nil
+	}
+
 	for _, consumer := range kc.consumers {
 		if err := consumer.Close(); err != nil {
 			return err
@@ -110,6 +114,8 @@ func (om *OpenMock) startKafka() {
 			}
 			logrus.Infof("consumer started for topic:%s", kafka.Topic)
 			om.kafkaClient.consumers = append(om.kafkaClient.consumers, consumer)
+
+			//nolint:gosimple
 			for {
 				select {
 				case msg, ok := <-consumer.Messages():

--- a/redis.go
+++ b/redis.go
@@ -90,14 +90,3 @@ func redisDo(om *OpenMock) func(keyAndArgs ...interface{}) interface{} {
 		return v
 	}
 }
-
-func parseCommand(cmd string) (name string, args []interface{}) {
-	cmds := strings.Split(cmd, " ")
-	if len(cmds) == 1 {
-		return cmds[0], nil
-	}
-	for _, a := range cmds[1:] {
-		args = append(args, a)
-	}
-	return cmds[0], args
-}

--- a/redis_test.go
+++ b/redis_test.go
@@ -29,8 +29,10 @@ func TestRedis(t *testing.T) {
 	})
 
 	t.Run("rpush set array data", func(t *testing.T) {
-		v, err := redisHandleReply(om.redis.Do("rpush", "k1", "v1"))
-		v, err = redisHandleReply(om.redis.Do("rpush", "k1", "v2"))
+		_, err := redisHandleReply(om.redis.Do("rpush", "k1", "v1"))
+		assert.NoError(t, err)
+
+		v, err := redisHandleReply(om.redis.Do("rpush", "k1", "v2"))
 		assert.NoError(t, err)
 		assert.NotEmpty(t, v)
 	})

--- a/template_helper.go
+++ b/template_helper.go
@@ -121,6 +121,10 @@ func regexFindFirstSubmatch(regex string, s string) string {
 // hmacSHA256 computes SHA256 HMAC of data using secret
 func hmacSHA256(secret string, data string) string {
 	h := hmac.New(sha256.New, []byte(secret))
-	h.Write([]byte(data))
+	_, err := h.Write([]byte(data))
+	if err != nil {
+		logrus.WithField("err", err).Error("failed to hmacSHA256")
+		return ""
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/template_helper_test.go
+++ b/template_helper_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestJSONPath(t *testing.T) {
+	var tmpl string
 	var ret string
 	var err error
-	var tmpl string
 
 	tmpl = `{"transaction_id": "t1234"}`
 	ret, err = jsonPath("/transaction_id", tmpl)


### PR DESCRIPTION
Fixing all the linter issues


e.g.
```
handle_actions_test.go:24: File is not `gofmt`-ed with `-s` (gofmt)                                                            
                        Actions: []ActionDispatcher{ActionDispatcher{}},                                                       
openmock.go:12:15: struct of size 248 bytes could be of size 224 bytes (maligned)                                              
type OpenMock struct {                                                             
              ^                                                                                                                
handle_actions_test.go:51:25: Error return value of `unActingMock.DoActions` is not checked (errcheck)               
                unActingMock.DoActions(Context{})                    
                                      ^                                                                                        
handle_actions_test.go:69:23: Error return value of `actingMock.DoActions` is not checked (errcheck)
                actingMock.DoActions(Context{})                                    
                                    ^                                                                                           load.go:207:38: Error return value of `(*github.com/checkr/openmock/vendor/github.com/fatih/structs.Field).Set` is not checked (
errcheck)                                                                                                                      
                        baseStruct.Field(field.Name()).Set(field.Value())                           
                                                          ^                                                                    
openmock.go:42:11: Error return value of `env.Parse` is not checked (errcheck)     
        env.Parse(om)                                                                                                           
                 ^                                                                                                              
template_helper.go:124:9: Error return value of `h.Write` is not checked (errcheck)                           
        h.Write([]byte(data))                                                                                 
               ^                                                                                                                handle_actions.go:39:1: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (
golint)                                                                                                                        
func (self ActionSendHTTP) Perform(context Context) error {                                                                    
^                                                                                                                               handle_actions.go:65:1: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (
golint)                                                                                                                         
func (self ActionReplyHTTP) Perform(context Context) error {                                             
^                                                                                                                               handle_actions.go:82:1: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (
golint)                                                                                               
func (self ActionRedis) Perform(context Context) error {                                                                 
^                                                                                                                              
kafka.go:55:24: U1000: func `(*kafkaClient).close` is unused (unused)                                       
func (kc *kafkaClient) close() error {                                                                      
                       ^                                                                                                       
kafka.go:113:4: S1000: should use for range instead of for { select {} } (gosimple)                                             
                        for {                                                                                                   
                        ^                                                                                                       
load.go:120:5: SA4006: this value of `err` is never used (staticcheck)                                                          
        m, err := redis.StringMap(v, err)                                                    
           ^                                                                                                                   
load.go:151:9: S1030: should use w.Bytes() instead of []byte(w.String()) (gosimple)                                             
        return []byte(w.String()), nil                                                                                          
               ^                                                                                                               
redis_test.go:32:3: SA4006: this value of `v` is never used (staticcheck)                                                      
                v, err := redisHandleReply(om.redis.Do("rpush", "k1", "v1"))                                                    
                ^                                                                                                               
template_helper_test.go:12:2: S1021: should merge variable declaration with assignment on next line (gosimple)                  
        var tmpl string                                                                                                         
        ^                                                                            
openmock.go:42:11: Error return value of `env.Parse` is not checked (errcheck)                               
        env.Parse(om)
                 ^                                                                                           
template_helper.go:124:9: Error return value of `h.Write` is not checked (errcheck)                          
        h.Write([]byte(data))
               ^                                                                                             
handle_actions.go:39:1: receiver name should be a reflection of its identity; don't use generic names such as 
"this" or "self" (golint)                                                                                    
func (self ActionSendHTTP) Perform(context Context) error {                                                  
^                                                                                                            
handle_actions.go:65:1: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (golint)
func (self ActionReplyHTTP) Perform(context Context) error {                                                 
^
handle_actions.go:82:1: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (golint)
func (self ActionRedis) Perform(context Context) error {                                                     
^
kafka.go:55:24: U1000: func `(*kafkaClient).close` is unused (unused)                                        
func (kc *kafkaClient) close() error {                                                                       
                       ^                                                                                     
kafka.go:113:4: S1000: should use for range instead of for { select {} } (gosimple)                          
                        for {                                                                                
                        ^
load.go:120:5: SA4006: this value of `err` is never used (staticcheck)                                       
        m, err := redis.StringMap(v, err)                                                                    
           ^
load.go:151:9: S1030: should use w.Bytes() instead of []byte(w.String()) (gosimple)                          
        return []byte(w.String()), nil
               ^                                                                                             
redis_test.go:32:3: SA4006: this value of `v` is never used (staticcheck)                                    
                v, err := redisHandleReply(om.redis.Do("rpush", "k1", "v1"))                                 
                ^
template_helper_test.go:12:2: S1021: should merge variable declaration with assignment on next line (gosimple)        var tmpl string
        ^                                                            

```