### PR TITLE
Merge actions when extending AbstractBehavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Actions are a series of functions to run. Availabe actions are:
           Content-Type: text/html
 ```
 
-The actions by default run in the order defined in the mock file; you can adjust this by adding an int 'order' field.
+The actions by default run in the order defined in the mock file; you can adjust this by adding an int 'order' value from lowest to highest number. The default value for 'order' is 0.
 ```yaml
 - key: every-op
   kind: Behavior
@@ -199,8 +199,8 @@ Templates can be useful to assemble your payloads from parts
 
 ### Abstract Behaviors
 Abstract Behaviors can be used to parameterize some data.
-When an abstract behavior and a behavior extending it both have actions defined, all of them are run when the behavior matches.
 
+When an abstract behavior and a behavior extending it both have actions defined, all of them are run when the behavior matches.  Actions will run from lowest to highest value of the 'order' field; if this is the same for two actions the action defined earlier in the abstract behavior runs first, followed by actions in the concrete behavior.
 ```yaml
 - key: fruit-of-the-day
   kind: AbstractBehavior
@@ -232,7 +232,7 @@ When an abstract behavior and a behavior extending it both have actions defined,
     # sleep then reply_http
     - sleep:
          duration: 1s
-      order: -1
+      order: -1000
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,28 @@ Actions are a series of functions to run. Availabe actions are:
           Content-Type: text/html
 ```
 
+The actions by default run in the order defined in the mock file; you can adjust this by adding an int 'order' field.
+```yaml
+- key: every-op
+  kind: Behavior
+  expect:
+    http:
+      method: GET
+      path: /ping
+  actions:
+    - publish_kafka:
+        topic: hello_kafka_out
+        payload: >
+          {
+            "kafka": "OK",
+            "data": {}
+          }
+    - sleep:
+        duration: 1s
+      # sleep first
+      order: -1
+```
+
 ### Templates
 Templates can be useful to assemble your payloads from parts
 
@@ -176,7 +198,8 @@ Templates can be useful to assemble your payloads from parts
 ```
 
 ### Abstract Behaviors
-Abstract Behaviors can be used to parameterize some data
+Abstract Behaviors can be used to parameterize some data.
+When an abstract behavior and a behavior extending it both have actions defined, all of them are run when the behavior matches.
 
 ```yaml
 - key: fruit-of-the-day
@@ -205,6 +228,11 @@ Abstract Behaviors can be used to parameterize some data
   extend: fruit-of-the-day
   values:
     day: tuesday
+  actions: 
+    # sleep then reply_http
+    - sleep:
+         duration: 1s
+      order: -1
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The actions by default run in the order defined in the mock file; you can adjust
     - sleep:
         duration: 1s
       # sleep first
-      order: -1
+      order: -1000
 ```
 
 ### Templates

--- a/README.md
+++ b/README.md
@@ -503,11 +503,11 @@ package main
 
 import "github.com/checkr/openmock"
 
-func consumePipelineFunc(c *openmock.Context, in []byte) (out []byte, error) {
+func consumePipelineFunc(c openmock.Context, in []byte) (out []byte, error) {
   return decode(in), nil
 }
 
-func publishPipelineFunc(c *openmock.Context, in []byte) (out []byte, error) {
+func publishPipelineFunc(c openmock.Context, in []byte) (out []byte, error) {
   return encode(in), nil
 }
 

--- a/demo_templates/complicated_values.yml
+++ b/demo_templates/complicated_values.yml
@@ -1,0 +1,28 @@
+- key: complicated-values-template
+  kind: Template
+  template: >-
+    {{ cat 
+      .Values.root.branch.leaf.info 
+      .Values.root.stem.thing
+      .Values.root.item
+    }}
+
+- key: complicated-values-user
+  kind: Behavior
+  expect:
+    http:
+      method: GET
+      path: /muskrat
+  values:
+    root:
+      branch:
+        leaf:
+          info: 1
+      stem:
+        thing: 2
+      item: 3
+  actions:
+    - reply_http:
+        status_code: 418
+        body: >
+          {{ template "complicated-values-template" . }}

--- a/demo_templates/ordered_actions.yml
+++ b/demo_templates/ordered_actions.yml
@@ -26,7 +26,7 @@
   actions: 
     - sleep: 
         duration: 1s
-      order: -1
+      order: -1000
   expect: 
     http: 
       method: GET

--- a/demo_templates/ordered_actions.yml
+++ b/demo_templates/ordered_actions.yml
@@ -1,0 +1,16 @@
+- key: ping
+  kind: Behavior
+  expect:
+    http:
+      method: GET
+      path: /ping
+  actions:
+    - order: 1
+      reply_http:
+        status_code: 200
+        body: OK
+        headers:
+          Content-Type: text/xml
+    - order: 0
+      redis: 
+        - "hello"

--- a/demo_templates/ordered_actions.yml
+++ b/demo_templates/ordered_actions.yml
@@ -1,16 +1,35 @@
-- key: ping
-  kind: Behavior
-  expect:
-    http:
-      method: GET
-      path: /ping
-  actions:
+- key: ordered_actions
+  actions: 
     - order: 1
-      reply_http:
-        status_code: 200
+      reply_http: 
         body: OK
-        headers:
+        headers: 
           Content-Type: text/xml
+        status_code: 200
     - order: 0
-      redis: 
-        - "hello"
+      sleep: 
+        duration: 1s
+  expect: 
+    http: 
+      method: GET
+      path: /ping2
+  kind: Behavior
+- key: abstract_with_action
+  actions: 
+    - reply_http: 
+        body: OK
+        headers: 
+          Content-Type: text/plain
+        status_code: 200
+  kind: AbstractBehavior
+- key: merge_actions
+  actions: 
+    - sleep: 
+        duration: 1s
+      order: -1
+  expect: 
+    http: 
+      method: GET
+      path: /merge_actions
+  extend: abstract_with_action
+  kind: Behavior

--- a/load.go
+++ b/load.go
@@ -110,13 +110,13 @@ func (om *OpenMock) populateBehaviors(mocks []*Mock) {
 		}
 
 		if len(r.Behaviors[m.Key].Actions) > 0 {
-			ordered_actions := r.Behaviors[m.Key].Actions
-			sort.Slice(ordered_actions, func(i, j int) bool {
-				return ordered_actions[i].Order < ordered_actions[j].Order
+			orderedActions := r.Behaviors[m.Key].Actions
+			sort.Slice(orderedActions, func(i, j int) bool {
+				return orderedActions[i].Order < orderedActions[j].Order
 			})
-			if !actionsEqual(ordered_actions, r.Behaviors[m.Key].Actions) {
+			if !actionsEqual(orderedActions, r.Behaviors[m.Key].Actions) {
 				m = r.Behaviors[m.Key].patchedWith(Mock{
-					Actions: ordered_actions,
+					Actions: orderedActions,
 				})
 				r.Behaviors[m.Key] = m
 			}
@@ -223,6 +223,8 @@ func (m Mock) patchedWith(patch Mock) *Mock {
 		values[key] = value
 	}
 
+	actions := append(m.Actions, patch.Actions...)
+
 	baseStruct := structs.New(&m)
 	patchStruct := structs.New(patch)
 	for _, field := range patchStruct.Fields() {
@@ -238,6 +240,7 @@ func (m Mock) patchedWith(patch Mock) *Mock {
 		}
 	}
 	m.Values = values
+	m.Actions = actions
 
 	return &m
 }

--- a/load_test.go
+++ b/load_test.go
@@ -93,13 +93,44 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadBehaviors(t *testing.T) {
-	om := &OpenMock{}
-	om.setupRepo()
-	ping := &Mock{
-		Key: "ping",
-	}
-	om.populateBehaviors(MocksArray{ping})
-	assert.Equal(t, ping, om.repo.Behaviors["ping"])
+	t.Run("happy path", func(t *testing.T) {
+		om := &OpenMock{}
+		om.setupRepo()
+		ping := &Mock{
+			Key: "ping",
+		}
+		om.populateBehaviors(MocksArray{ping})
+		assert.Equal(t, ping, om.repo.Behaviors["ping"])
+	})
+	t.Run("actions are ordered if order specified", func(t *testing.T) {
+		om := &OpenMock{}
+		om.setupRepo()
+		expected_actions := []ActionDispatcher{
+			{
+				Order:       0,
+				ActionRedis: ActionRedis{"potato", "potato"},
+			},
+			{
+				Order:           1,
+				ActionReplyHTTP: ActionReplyHTTP{Body: "banana"},
+			},
+		}
+		ping := &Mock{
+			Key: "ping",
+			Actions: []ActionDispatcher{
+				{
+					Order:           1,
+					ActionReplyHTTP: ActionReplyHTTP{Body: "banana"},
+				},
+				{
+					Order:       0,
+					ActionRedis: ActionRedis{"potato", "potato"},
+				},
+			},
+		}
+		om.populateBehaviors(MocksArray{ping})
+		assert.Equal(t, expected_actions, om.repo.Behaviors["ping"].Actions)
+	})
 }
 
 func TestLoadExtendedBehaviors(t *testing.T) {

--- a/load_test.go
+++ b/load_test.go
@@ -105,7 +105,7 @@ func TestLoadBehaviors(t *testing.T) {
 	t.Run("actions are ordered if order specified", func(t *testing.T) {
 		om := &OpenMock{}
 		om.setupRepo()
-		expected_actions := []ActionDispatcher{
+		expectedActions := []ActionDispatcher{
 			{
 				Order:       0,
 				ActionRedis: ActionRedis{"potato", "potato"},
@@ -129,7 +129,7 @@ func TestLoadBehaviors(t *testing.T) {
 			},
 		}
 		om.populateBehaviors(MocksArray{ping})
-		assert.Equal(t, expected_actions, om.repo.Behaviors["ping"].Actions)
+		assert.Equal(t, expectedActions, om.repo.Behaviors["ping"].Actions)
 	})
 }
 
@@ -183,6 +183,28 @@ func TestLoadExtendedBehaviors(t *testing.T) {
 		om.setupRepo()
 		om.populateBehaviors(MocksArray{concrete, abstract})
 		assert.Equal(t, 1, len(om.repo.HTTPMocks[expectHTTP]))
+	})
+
+	concreteWithActions := &Mock{
+		Key:    "concreteWithActions",
+		Expect: Expect{HTTP: expectHTTP},
+		Extend: "abstract",
+		Values: map[string]interface{}{
+			"foo": "bar",
+		},
+		Actions: []ActionDispatcher{{
+			Order:       1,
+			ActionRedis: ActionRedis{"hi", "bye"},
+		}},
+	}
+
+	t.Run("combines actions", func(t *testing.T) {
+		om := &OpenMock{}
+		om.setupRepo()
+		om.populateBehaviors(MocksArray{abstract, concreteWithActions})
+		assert.NotZero(t, om.repo.Behaviors["concreteWithActions"].Actions)
+		assert.Equal(t, "banana", om.repo.Behaviors["concreteWithActions"].Actions[0].ActionReplyHTTP.Body)
+		assert.Equal(t, "hi", om.repo.Behaviors["concreteWithActions"].Actions[1].ActionRedis[0])
 	})
 }
 

--- a/model.go
+++ b/model.go
@@ -114,7 +114,7 @@ type (
 
 // Action represents actions
 type ActionDispatcher struct {
-	Order              int                `yaml:"order"`
+	Order              int                `yaml:"order,omitempty"`
 	ActionPublishAMQP  ActionPublishAMQP  `yaml:"publish_amqp,omitempty"`
 	ActionPublishKafka ActionPublishKafka `yaml:"publish_kafka,omitempty"`
 	ActionRedis        ActionRedis        `yaml:"redis,omitempty"`

--- a/model.go
+++ b/model.go
@@ -114,6 +114,7 @@ type (
 
 // Action represents actions
 type ActionDispatcher struct {
+	Order              int                `yaml:"order"`
 	ActionPublishAMQP  ActionPublishAMQP  `yaml:"publish_amqp,omitempty"`
 	ActionPublishKafka ActionPublishKafka `yaml:"publish_kafka,omitempty"`
 	ActionRedis        ActionRedis        `yaml:"redis,omitempty"`


### PR DESCRIPTION
- when extending an AbstractBehavior, run all of the actions defined for both the abstract behavior and the concrete behavior
- to allow customization when needed in extending, add an 'order' field to determine the order the actions are run