### PR TITLE
Add hot reload env var

### DIFF
--- a/openmock.go
+++ b/openmock.go
@@ -14,21 +14,22 @@ import (
 // OpenMock holds all the configuration of running openmock
 type OpenMock struct {
 	// Env configuration
-	LogLevel         string   `env:"OPENMOCK_LOG_LEVEL" envDefault:"info"`
-	TemplatesDir     string   `env:"OPENMOCK_TEMPLATES_DIR" envDefault:"./templates"`
-	HTTPEnabled      bool     `env:"OPENMOCK_HTTP_ENABLED" envDefault:"true"`
-	HTTPPort         int      `env:"OPENMOCK_HTTP_PORT" envDefault:"9999"`
-	HTTPHost         string   `env:"OPENMOCK_HTTP_HOST" envDefault:"0.0.0.0"`
-	AdminHTTPEnabled bool     `env:"OPENMOCK_ADMIN_HTTP_ENABLED" envDefault:"true"`
-	AdminHTTPPort    int      `env:"OPENMOCK_ADMIN_HTTP_PORT" envDefault:"9998"`
-	AdminHTTPHost    string   `env:"OPENMOCK_ADMIN_HTTP_HOST" envDefault:"0.0.0.0"`
-	KafkaEnabled     bool     `env:"OPENMOCK_KAFKA_ENABLED" envDefault:"false"`
-	KafkaClientID    string   `env:"OPENMOCK_KAFKA_CLIENT_ID" envDefault:"openmock"`
-	KafkaSeedBrokers []string `env:"OPENMOCK_KAFKA_SEED_BROKERS" envDefault:"kafka:9092,localhost:9092" envSeparator:","`
-	AMQPEnabled      bool     `env:"OPENMOCK_AMQP_ENABLED" envDefault:"false"`
-	AMQPURL          string   `env:"OPENMOCK_AMQP_URL" envDefault:"amqp://guest:guest@rabbitmq:5672"`
-	RedisType        string   `env:"OPENMOCK_REDIS_TYPE" envDefault:"memory"`
-	RedisURL         string   `env:"OPENMOCK_REDIS_URL" envDefault:"redis://redis:6379"`
+	LogLevel              string   `env:"OPENMOCK_LOG_LEVEL" envDefault:"info"`
+	TemplatesDir          string   `env:"OPENMOCK_TEMPLATES_DIR" envDefault:"./templates"`
+	TemplatesDirHotReload bool     `env:"OPENMOCK_TEMPLATES_DIR_HOT_RELOAD" envDefault:"true"`
+	HTTPEnabled           bool     `env:"OPENMOCK_HTTP_ENABLED" envDefault:"true"`
+	HTTPPort              int      `env:"OPENMOCK_HTTP_PORT" envDefault:"9999"`
+	HTTPHost              string   `env:"OPENMOCK_HTTP_HOST" envDefault:"0.0.0.0"`
+	AdminHTTPEnabled      bool     `env:"OPENMOCK_ADMIN_HTTP_ENABLED" envDefault:"true"`
+	AdminHTTPPort         int      `env:"OPENMOCK_ADMIN_HTTP_PORT" envDefault:"9998"`
+	AdminHTTPHost         string   `env:"OPENMOCK_ADMIN_HTTP_HOST" envDefault:"0.0.0.0"`
+	KafkaEnabled          bool     `env:"OPENMOCK_KAFKA_ENABLED" envDefault:"false"`
+	KafkaClientID         string   `env:"OPENMOCK_KAFKA_CLIENT_ID" envDefault:"openmock"`
+	KafkaSeedBrokers      []string `env:"OPENMOCK_KAFKA_SEED_BROKERS" envDefault:"kafka:9092,localhost:9092" envSeparator:","`
+	AMQPEnabled           bool     `env:"OPENMOCK_AMQP_ENABLED" envDefault:"false"`
+	AMQPURL               string   `env:"OPENMOCK_AMQP_URL" envDefault:"amqp://guest:guest@rabbitmq:5672"`
+	RedisType             string   `env:"OPENMOCK_REDIS_TYPE" envDefault:"memory"`
+	RedisURL              string   `env:"OPENMOCK_REDIS_URL" envDefault:"redis://redis:6379"`
 
 	// Customized pipeline functions
 	KafkaConsumePipelineFunc KafkaPipelineFunc
@@ -103,12 +104,14 @@ func (om *OpenMock) Start() {
 		go om.startAMQP()
 	}
 
-	go func() {
-		err := reload.Do(logrus.Infof, reload.Dir(om.TemplatesDir, reload.Exec))
-		if err != nil {
-			logrus.Fatal(err)
-		}
-	}()
+	if om.TemplatesDirHotReload {
+		go func() {
+			err := reload.Do(logrus.Infof, reload.Dir(om.TemplatesDir, reload.Exec))
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		}()
+	}
 
 	waitForSignal()
 }


### PR DESCRIPTION
Sometimes we saw things like:

```
time="2019-12-04T22:08:21Z" level=info msg="template with key:verifications loaded."
time="2019-12-04T22:08:21Z" level=fatal msg="cannot setup watcher: too many open files"
```

If the openmock setup doesn't need hot reload (e.g. in a stable environment), we can disable this feature.