### PR TITLE
EVER-1852 Perform http_requests async

### DIFF
--- a/handle_actions.go
+++ b/handle_actions.go
@@ -28,13 +28,7 @@ func (m *Mock) DoActions(c Context) error {
 
 	for _, actionDispatcher := range m.Actions {
 		actualAction := getActualAction(actionDispatcher)
-		_, isReplyHTTP := actualAction.(ActionReplyHTTP)
-
-		if isReplyHTTP {
-			defer actualAction.Perform(c)
-		} else {
-			actualAction.Perform(c)
-		}
+		actualAction.Perform(c)
 	}
 
 	return nil

--- a/handle_actions.go
+++ b/handle_actions.go
@@ -28,6 +28,7 @@ func (m *Mock) DoActions(c Context) error {
 	for _, actionDispatcher := range m.Actions {
 		actualAction := getActualAction(actionDispatcher)
 		_, isReplyHTTP := actualAction.(ActionReplyHTTP)
+		_, isSendHTTP := actualAction.(ActionSendHTTP)
 
 		if isReplyHTTP {
 			if replyAction != nil {
@@ -35,10 +36,12 @@ func (m *Mock) DoActions(c Context) error {
 			}
 
 			replyAction = actualAction
-		} else {
+		} else if isSendHTTP {
 			go func(actualAction Action, c Context) {
 				performAction(actualAction, c)
 			}(actualAction, c)
+		} else {
+			performAction(actualAction, c)
 		}
 	}
 

--- a/handle_actions.go
+++ b/handle_actions.go
@@ -37,9 +37,7 @@ func (m *Mock) DoActions(c Context) error {
 // Perform defines the action to perform for the ActionSendHTTP action
 func (a ActionSendHTTP) Perform(context Context) {
 	go func() {
-		if a.Sleep != 0 {
-			time.Sleep(a.Sleep)
-		}
+		time.Sleep(a.Sleep)
 
 		bodyStr, err := context.Render(a.Body)
 		if err != nil {

--- a/handle_actions.go
+++ b/handle_actions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// DoActions performs all actions for a given MocksArray
 func (ms MocksArray) DoActions(c Context) error {
 	for _, m := range ms {
 		if err := m.DoActions(c); err != nil {
@@ -18,82 +19,59 @@ func (ms MocksArray) DoActions(c Context) error {
 	return nil
 }
 
+// DoActions checks if a given condition matches and performs each action defined by m.Actions
 func (m *Mock) DoActions(c Context) error {
 	c.Values = m.Values
 	if !c.MatchCondition(m.Expect.Condition) {
 		return nil
 	}
-	var replyAction Action
 
 	for _, actionDispatcher := range m.Actions {
 		actualAction := getActualAction(actionDispatcher)
 		_, isReplyHTTP := actualAction.(ActionReplyHTTP)
-		_, isSendHTTP := actualAction.(ActionSendHTTP)
 
 		if isReplyHTTP {
-			if replyAction != nil {
-				logrus.Fatalf("More than 1 reply_http defined for http behavior")
-			}
-
-			replyAction = actualAction
-		} else if isSendHTTP {
-			go func(actualAction Action, c Context) {
-				performAction(actualAction, c)
-			}(actualAction, c)
+			defer actualAction.Perform(c)
 		} else {
-			performAction(actualAction, c)
+			actualAction.Perform(c)
 		}
 	}
 
-	if replyAction != nil {
-		performAction(replyAction, c)
-	}
-
 	return nil
 }
 
-func performAction(action Action, c Context) {
-	err := action.Perform(c)
+// Perform defines the action to perform for the ActionSendHTTP action
+func (a ActionSendHTTP) Perform(context Context) {
+	go func(a ActionSendHTTP) {
+		if a.Sleep != 0 {
+			time.Sleep(a.Sleep)
+		}
 
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"err":    err,
-			"action": fmt.Sprintf("%T", action),
-		}).Errorf("failed to do action")
-	}
+		bodyStr, err := context.Render(a.Body)
+		handleActionErr(a, err)
+
+		urlStr, err := context.Render(a.URL)
+		handleActionErr(a, err)
+
+		request := gorequest.New().
+			SetDebug(true).
+			CustomMethod(a.Method, urlStr)
+
+		for k, v := range a.Headers {
+			request.Set(k, v)
+		}
+
+		_, _, errs := request.Send(bodyStr).End()
+		if len(errs) != 0 {
+			if errs[0] != nil {
+				handleActionErr(a, errs[0])
+			}
+		}
+	}(a)
 }
 
-func (a ActionSendHTTP) Perform(context Context) error {
-	if a.Sleep != 0 {
-		time.Sleep(a.Sleep)
-	}
-
-	bodyStr, err := context.Render(a.Body)
-	if err != nil {
-		return err
-	}
-
-	urlStr, err := context.Render(a.URL)
-	if err != nil {
-		return err
-	}
-
-	request := gorequest.New().
-		SetDebug(true).
-		CustomMethod(a.Method, urlStr)
-
-	for k, v := range a.Headers {
-		request.Set(k, v)
-	}
-
-	_, _, errs := request.Send(bodyStr).End()
-	if len(errs) != 0 {
-		return errs[0]
-	}
-	return nil
-}
-
-func (a ActionReplyHTTP) Perform(context Context) error {
+// Perform defines the action to perform for the ActionReplyHTTP action
+func (a ActionReplyHTTP) Perform(context Context) {
 	ec := context.HTTPContext
 	contentType := echo.MIMEApplicationJSON // default to JSON
 	if ct, ok := a.Headers[echo.HeaderContentType]; ok {
@@ -106,45 +84,43 @@ func (a ActionReplyHTTP) Perform(context Context) error {
 	msg, err := context.Render(a.Body)
 	if err != nil {
 		logrus.WithField("err", err).Error("failed to render template for http")
-		return err
 	}
-	return ec.Blob(a.StatusCode, contentType, []byte(msg))
+
+	err = ec.Blob(a.StatusCode, contentType, []byte(msg))
+	handleActionErr(a, err)
 }
 
-func (a ActionRedis) Perform(context Context) error {
+// Perform defines the action to perform for the ActionRedis action
+func (a ActionRedis) Perform(context Context) {
 	for _, cmd := range a {
 		_, err := context.Render(cmd)
-		if err != nil {
-			return err
-		}
+		handleActionErr(a, err)
 	}
-	return nil
 }
 
-func (a ActionSleep) Perform(context Context) error {
+// Perform defines the action to perform for the ActionSleep action
+func (a ActionSleep) Perform(context Context) {
 	time.Sleep(a.Duration)
-	return nil
 }
 
-func (a ActionPublishKafka) Perform(context Context) error {
+// Perform defines the action to perform for the ActionPublishKafka action
+func (a ActionPublishKafka) Perform(context Context) {
 	msg := a.Payload
 	msg, err := context.Render(msg)
 	if err != nil {
 		logrus.WithField("err", err).Error("failed to render template for kafka payload")
-		return err
 	}
 	err = context.om.kafkaClient.sendMessage(a.Topic, []byte(msg))
 	if err != nil {
 		logrus.WithField("err", err).Error("failed to publish to kafka")
 	}
-	return err
 }
 
-func (a ActionPublishAMQP) Perform(context Context) error {
+// Perform defines the action to perform for the ActionPublishAMQP action
+func (a ActionPublishAMQP) Perform(context Context) {
 	msg, err := context.Render(a.Payload)
 	if err != nil {
 		logrus.WithField("err", err).Error("failed to render template for amqp")
-		return err
 	}
 	publishToAMQP(
 		context.om.AMQPURL,
@@ -152,5 +128,13 @@ func (a ActionPublishAMQP) Perform(context Context) error {
 		a.RoutingKey,
 		msg,
 	)
-	return nil
+}
+
+func handleActionErr(a Action, err error) {
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"err":    err,
+			"action": fmt.Sprintf("%T", a),
+		}).Errorf("failed to do action")
+	}
 }

--- a/handle_actions.go
+++ b/handle_actions.go
@@ -19,7 +19,7 @@ func (ms MocksArray) DoActions(c Context) error {
 	return nil
 }
 
-// DoActions checks if a given condition matches and performs each action defined by m.Actions
+// DoActions checks if a given condition matches and performs each action in m.Actions
 func (m *Mock) DoActions(c Context) error {
 	c.Values = m.Values
 	if !c.MatchCondition(m.Expect.Condition) {
@@ -36,7 +36,7 @@ func (m *Mock) DoActions(c Context) error {
 
 // Perform defines the action to perform for the ActionSendHTTP action
 func (a ActionSendHTTP) Perform(context Context) {
-	go func(a ActionSendHTTP) {
+	go func() {
 		if a.Sleep != 0 {
 			time.Sleep(a.Sleep)
 		}
@@ -61,7 +61,7 @@ func (a ActionSendHTTP) Perform(context Context) {
 				handleActionErr(a, errs[0])
 			}
 		}
-	}(a)
+	}()
 }
 
 // Perform defines the action to perform for the ActionReplyHTTP action

--- a/handle_actions.go
+++ b/handle_actions.go
@@ -42,10 +42,14 @@ func (a ActionSendHTTP) Perform(context Context) {
 		}
 
 		bodyStr, err := context.Render(a.Body)
-		handleActionErr(a, err)
+		if err != nil {
+			handleActionErr(a, err)
+		}
 
 		urlStr, err := context.Render(a.URL)
-		handleActionErr(a, err)
+		if err != nil {
+			handleActionErr(a, err)
+		}
 
 		request := gorequest.New().
 			SetDebug(true).
@@ -81,14 +85,18 @@ func (a ActionReplyHTTP) Perform(context Context) {
 	}
 
 	err = ec.Blob(a.StatusCode, contentType, []byte(msg))
-	handleActionErr(a, err)
+	if err != nil {
+		handleActionErr(a, err)
+	}
 }
 
 // Perform defines the action to perform for the ActionRedis action
 func (a ActionRedis) Perform(context Context) {
 	for _, cmd := range a {
 		_, err := context.Render(cmd)
-		handleActionErr(a, err)
+		if err != nil {
+			handleActionErr(a, err)
+		}
 	}
 }
 
@@ -125,10 +133,8 @@ func (a ActionPublishAMQP) Perform(context Context) {
 }
 
 func handleActionErr(a Action, err error) {
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"err":    err,
-			"action": fmt.Sprintf("%T", a),
-		}).Errorf("failed to do action")
-	}
+	logrus.WithFields(logrus.Fields{
+		"err":    err,
+		"action": fmt.Sprintf("%T", a),
+	}).Errorf("failed to do action")
 }

--- a/handle_actions_test.go
+++ b/handle_actions_test.go
@@ -12,10 +12,9 @@ type FakePerformer struct {
 	Performed       bool
 }
 
-func (fp *FakePerformer) Perform(context Context) error {
+func (fp *FakePerformer) Perform(context Context) {
 	fp.Performed = true
 	fp.ReceivedContext = context
-	return nil
 }
 
 func TestContextUpdate(t *testing.T) {

--- a/model.go
+++ b/model.go
@@ -124,7 +124,7 @@ type ActionDispatcher struct {
 }
 
 type Action interface {
-	Perform(context Context) error
+	Perform(context Context)
 }
 
 // ActionRedis represents a list of redis commands

--- a/model.go
+++ b/model.go
@@ -137,6 +137,7 @@ type ActionSendHTTP struct {
 	Headers      map[string]string `yaml:"headers,omitempty"`
 	Body         string            `yaml:"body,omitempty"`
 	BodyFromFile string            `yaml:"body_from_file,omitempty"`
+	Sleep        time.Duration     `yaml:"sleep,omitempty"`
 }
 
 // ActionReplyHTTP represents reply http action


### PR DESCRIPTION
In order to simulate webhooks we currently create actions like:
```
actions:
     - publish_kafka:
        topic: delayed-webhook
        payload_from_file: ./delayed_webhook_data
     - publish_kafka:
        topic: other-delayed-webhook
        payload_from_file: ./other_delayed_webhook_data
     - reply_http:
        status_code: 200
```
then create consumers for those webhooks like
```
- key: delayed-webhook
  expect:
    kafka:
      topic: delayed-webhook
    - sleep:
        duration: 10s
    - send_http:
        url: https://checkrhq-dev.net/
        method: POST
```
we have to do it this way since actions are executed synchronously. this can easily create confusion and introduce bugs when we are trying to simulate more complex workflows and webhook events by daisy-chaining kafka messages

This PR makes it so that all send-http actions are performed in a goroutine and adds a new `Sleep` field to send-http actions. this allows us to make clearer `m.Actions` arrays in the templates, for example we can simulate webhooks like this:
```
actions:
     - reply_http:
        status_code: 200
    - send_http:
          sleep: 10s
          url: https://checkrhq-dev.net/webhook_1
          method: POST
    - send_http:
          sleep: 20s
          url: https://checkrhq-dev.net/webhook_2
          method: POST
```

## TODO
- [ ] tests
- [ ] update demo templates

I'll go ahead and complete these 2 TODOs if folks agree that this is a workable solution