### PR TITLE
Implement post-key for manipulating the OM model via the HTTP admin interface

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -16,11 +16,9 @@ import (
 
 const reloadDelay = time.Second
 
-const postKeyHeader = "X-OPENMOCK-POST-KEY"
-
 func getRedisKey(c echo.Context) (redisKey string) {
 	redisKey = redisTemplatesStore
-	alternativeKey := c.Request().Header.Get(postKeyHeader)
+	alternativeKey := c.Param("set_key")
 	if alternativeKey != "" {
 		redisKey = redisKey + "_" + alternativeKey
 	}
@@ -127,6 +125,8 @@ func (om *OpenMock) StartAdmin() {
 	e.Use(em.Logrus())
 
 	e.POST("/api/v1/templates", PostTemplates(om, true))
+	e.POST("/api/v1/template_sets/:set_key", PostTemplates(om, true))
+	e.DELETE("/api/v1/template_sets/:set_key", DeleteTemplates(om, true))
 	e.DELETE("/api/v1/templates", DeleteTemplates(om, true))
 	e.DELETE("/api/v1/templates/:key", DeleteTemplateByKey(om, true))
 	e.GET("/api/v1/templates", GetTemplates(om))

--- a/admin_test.go
+++ b/admin_test.go
@@ -1,0 +1,150 @@
+package openmock
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func getTestOM(t *testing.T) *OpenMock {
+	om := &OpenMock{
+		TemplatesDir: "demo_templates",
+	}
+	om.SetupRepo()
+	err := om.Load()
+	assert.NoError(t, err)
+	om.RedisType = ""
+	om.SetRedis()
+	return om
+}
+
+func testRequest(method, path string, e *echo.Echo) (int, string) {
+	return testRequestBody(method, path, e, nil)
+}
+
+func testRequestBody(method, path string, e *echo.Echo, body io.Reader) (int, string) {
+	req := httptest.NewRequest(method, path, body)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+// type FakeRedis struct {
+// }
+
+// func (fr *FakeRedis) hset(key string, field string, value string) (reply interface{}, err error) {
+// 	return "", nil
+// }
+
+// func (fr *FakeRedis) hdel(key string, field string) (reply interface{}, err error) {
+// 	return "", nil
+// }
+
+// func (fr *FakeRedis) hget(key string, field string) (reply interface{}, err error) {
+// 	return "", nil
+// }
+
+// func (fr *FakeRedis) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+// 	switch commandName {
+// 	case "HSET":
+// 		return fr.hset(args[0].(string), args[1].(string), args[2].(string))
+// 	case "HDEL":
+// 		return fr.hdel(args[0].(string), args[1].(string))
+// 	case "HGET":
+// 		return fr.hget(args[0].(string), args[1].(string))
+// 	default:
+// 		return "", fmt.Errorf("Unknown FakeRedis command %s", commandName)
+// 	}
+// }
+
+func TestGetTemplates(t *testing.T) {
+	t.Run("Get Templates returns YAML", func(t *testing.T) {
+		om := getTestOM(t)
+		handler := GetTemplates(om)
+
+		assert.NotNil(t, handler)
+
+		e := echo.New()
+		e.GET("/", handler)
+		c, b := testRequest(http.MethodGet, "/", e)
+		assert.Equal(t, http.StatusOK, c)
+
+		mocks := []*Mock{}
+		if err := yaml.UnmarshalStrict([]byte(b), &mocks); err != nil {
+			t.FailNow()
+		}
+
+		for _, m := range mocks {
+			if m.Key == "ping" {
+				assert.Equal(t, m, om.repo.Behaviors["ping"])
+			}
+		}
+	})
+}
+
+func TestDeleteTemplateByKey(t *testing.T) {
+	om := getTestOM(t)
+	handler := DeleteTemplateByKey(om, false)
+	e := echo.New()
+	e.DELETE("/:key", handler)
+
+	t.Run("Delete template at key deletes it", func(t *testing.T) {
+		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
+		if err != nil {
+			t.FailNow()
+		}
+
+		c, b := testRequest(http.MethodDelete, "/123", e)
+		assert.Equal(t, http.StatusOK, c)
+		assert.NotEmpty(t, b)
+
+		v, err := om.redis.Do("HGET", redisTemplatesStore, "123")
+		result, err := redis.Bytes(v, err)
+		assert.NotEmpty(t, err)
+		assert.Equal(t, string(result), "")
+	})
+	t.Run("Delete non-existing key", func(t *testing.T) {
+		c, _ := testRequest(http.MethodDelete, "/123", e)
+		// assert.Equal(t, http.StatusNotFound, c) // TODO catch exception in echo when running redigo
+		assert.Equal(t, http.StatusInternalServerError, c)
+	})
+}
+
+func TestPostTemplates(t *testing.T) {
+	om := getTestOM(t)
+	handler := PostTemplates(om, false)
+	e := echo.New()
+	e.POST("/", handler)
+
+	t.Run("Post Happy path", func(t *testing.T) {
+		bodyReader := strings.NewReader(`
+- key: 123
+  kind: Behavior
+  expect:
+    http:
+      method: GET
+      path: /ping
+  actions:
+    - reply_http:
+        status_code: 200
+        body: OK
+        headers:
+          Content-Type: text/xml	
+    `)
+		c, b := testRequestBody(http.MethodPost, "/", e, bodyReader)
+		assert.Equal(t, http.StatusOK, c)
+		assert.NotEmpty(t, b)
+
+		v, err := om.redis.Do("HGET", redisTemplatesStore, "123")
+		result, err := redis.Bytes(v, err)
+		assert.Empty(t, err)
+		assert.NotEmpty(t, string(result))
+	})
+}

--- a/admin_test.go
+++ b/admin_test.go
@@ -56,9 +56,8 @@ func TestGetTemplates(t *testing.T) {
 		assert.Equal(t, http.StatusOK, c)
 
 		mocks := []*Mock{}
-		if err := yaml.UnmarshalStrict([]byte(b), &mocks); err != nil {
-			t.FailNow()
-		}
+		err := yaml.UnmarshalStrict([]byte(b), &mocks)
+		assert.NoError(t, err)
 
 		for _, m := range mocks {
 			if m.Key == "ping" {
@@ -76,9 +75,7 @@ func TestDeleteTemplates(t *testing.T) {
 		e.DELETE("/", handler)
 
 		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		c, b := testRequest(http.MethodDelete, "/", e)
 		assert.Equal(t, http.StatusNoContent, c)
@@ -98,14 +95,10 @@ func TestDeleteTemplates(t *testing.T) {
 		e.DELETE("/:set_key", handler)
 
 		_, err := om.redis.Do("HSET", redisTemplatesStore, "456", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		_, err = om.redis.Do("HSET", redisTemplatesStore+"_"+postKey, "123", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		c, b := testRequest(http.MethodDelete, "/"+postKey, e)
 		assert.Equal(t, http.StatusNoContent, c)
@@ -131,9 +124,7 @@ func TestDeleteTemplateByKey(t *testing.T) {
 
 	t.Run("Delete template at key deletes it", func(t *testing.T) {
 		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		c, b := testRequest(http.MethodDelete, "/123", e)
 		assert.Equal(t, http.StatusOK, c)

--- a/admin_test.go
+++ b/admin_test.go
@@ -95,7 +95,7 @@ func TestDeleteTemplates(t *testing.T) {
 		om := getTestOM(t)
 		handler := DeleteTemplates(om, false)
 		e := echo.New()
-		e.DELETE("/", handler)
+		e.DELETE("/:set_key", handler)
 
 		_, err := om.redis.Do("HSET", redisTemplatesStore, "456", "stuff")
 		if err != nil {
@@ -107,10 +107,7 @@ func TestDeleteTemplates(t *testing.T) {
 			t.FailNow()
 		}
 
-		headers := map[string]string{
-			postKeyHeader: postKey,
-		}
-		c, b := testRequestFull(http.MethodDelete, "/", e, nil, headers)
+		c, b := testRequest(http.MethodDelete, "/"+postKey, e)
 		assert.Equal(t, http.StatusNoContent, c)
 		assert.Empty(t, b)
 
@@ -159,6 +156,7 @@ func TestPostTemplates(t *testing.T) {
 	handler := PostTemplates(om, false)
 	e := echo.New()
 	e.POST("/", handler)
+	e.POST("/:set_key", handler)
 
 	bodyString := `
 - key: 123
@@ -189,11 +187,8 @@ func TestPostTemplates(t *testing.T) {
 
 	t.Run("Post with alternate key header", func(t *testing.T) {
 		postKey := "foobar"
-		headers := map[string]string{
-			postKeyHeader: postKey,
-		}
 		bodyReader := strings.NewReader(bodyString)
-		c, b := testRequestFull(http.MethodPost, "/", e, bodyReader, headers)
+		c, b := testRequestBody(http.MethodPost, "/"+postKey, e, bodyReader)
 		assert.Equal(t, http.StatusOK, c)
 		assert.NotEmpty(t, b)
 

--- a/admin_test.go
+++ b/admin_test.go
@@ -16,11 +16,11 @@ import (
 func getTestOM(t *testing.T) *OpenMock {
 	om := &OpenMock{
 		TemplatesDir: "demo_templates",
+		RedisType:    "",
 	}
 	om.SetupRepo()
 	err := om.Load()
 	assert.NoError(t, err)
-	om.RedisType = ""
 	om.SetRedis()
 	return om
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/parnurzeal/gorequest v0.0.0-20171015110455-8e3aed27fe49
 	github.com/pierrec/lz4 v2.0.3+incompatible // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/prashantv/gostub v1.0.0
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 // indirect
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/streadway/amqp v0.0.0-20180806233856-70e15c650864 h1:Oj3PUEs+OUSYUpn35O+BE/ivHGirKixA3+vqA0Atu9A=
 github.com/streadway/amqp v0.0.0-20180806233856-70e15c650864/go.mod h1:1WNBiOZtZQLpVAyu0iTduoJL9hEsMloAK5XWrtW0xdY=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/load.go
+++ b/load.go
@@ -136,14 +136,23 @@ func loadRedis(doer RedisDoer) (b []byte, err error) {
 	}
 
 	logrus.Infof("Start to load templates from redis")
-	v, err := doer.Do("HGETALL", redisTemplatesStore)
-	m, err := redis.StringMap(v, err)
+	r, err := doer.Do("KEYS", redisTemplatesStore+"*")
+	s, err := redis.Strings(r, err)
 	if err != nil {
 		return nil, err
 	}
+
 	ss := []string{}
-	for _, s := range m {
-		ss = append(ss, s)
+	for _, key := range s {
+		v, err := doer.Do("HGETALL", key)
+		m, err := redis.StringMap(v, err)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range m {
+			ss = append(ss, s)
+		}
 	}
 	return []byte(strings.Join(ss, "\n")), nil
 }

--- a/load_test.go
+++ b/load_test.go
@@ -6,6 +6,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLoadRedis(t *testing.T) {
+	om := &OpenMock{
+		RedisType: "",
+	}
+	om.SetRedis()
+	redis := om.redis
+
+	t.Run("load redis happy", func(t *testing.T) {
+		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
+		if err != nil {
+			t.FailNow()
+		}
+
+		bytes, err := loadRedis(redis)
+		assert.Empty(t, err)
+		assert.Equal(t, "stuff", string(bytes))
+
+		_, err = om.redis.Do("HDEL", redisTemplatesStore, "123")
+		if err != nil {
+			t.FailNow()
+		}
+	})
+	t.Run("load redis post keys", func(t *testing.T) {
+		postKey := "foobar"
+		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
+		if err != nil {
+			t.FailNow()
+		}
+		_, err = om.redis.Do("HSET", redisTemplatesStore+"_"+postKey, "123", "things")
+		if err != nil {
+			t.FailNow()
+		}
+
+		bytes, err := loadRedis(redis)
+		assert.Empty(t, err)
+		assert.Equal(t, "stuff\nthings", string(bytes))
+
+		_, err = om.redis.Do("HDEL", redisTemplatesStore, "123")
+		if err != nil {
+			t.FailNow()
+		}
+		_, err = om.redis.Do("HDEL", redisTemplatesStore+"_"+postKey, "123")
+		if err != nil {
+			t.FailNow()
+		}
+	})
+}
+
 func TestLoadFile(t *testing.T) {
 	t.Run("kafka payload", func(t *testing.T) {
 		m := &Mock{

--- a/load_test.go
+++ b/load_test.go
@@ -15,42 +15,32 @@ func TestLoadRedis(t *testing.T) {
 
 	t.Run("load redis happy", func(t *testing.T) {
 		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		bytes, err := loadRedis(redis)
 		assert.Empty(t, err)
 		assert.Equal(t, "stuff", string(bytes))
 
 		_, err = om.redis.Do("HDEL", redisTemplatesStore, "123")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 	})
 	t.Run("load redis post keys", func(t *testing.T) {
 		postKey := "foobar"
 		_, err := om.redis.Do("HSET", redisTemplatesStore, "123", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
+
 		_, err = om.redis.Do("HSET", redisTemplatesStore+"_"+postKey, "123", "things")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		bytes, err := loadRedis(redis)
 		assert.Empty(t, err)
 		assert.Equal(t, "stuff\nthings", string(bytes))
 
 		_, err = om.redis.Do("HDEL", redisTemplatesStore, "123")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
+
 		_, err = om.redis.Do("HDEL", redisTemplatesStore+"_"+postKey, "123")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 	})
 }
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -64,16 +64,12 @@ func TestRedisDo(t *testing.T) {
 	t.Run("errors on template store args", func(t *testing.T) {
 		key := redisTemplatesStore + "_asdf123"
 		_, err := om.redis.Do("HSET", key, "123", "stuff")
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 
 		v := r("SET", key, "123", "things")
 		assert.Error(t, v.(error))
 
 		_, err = om.redis.Do("DEL", key)
-		if err != nil {
-			t.FailNow()
-		}
+		assert.NoError(t, err)
 	})
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -45,7 +45,9 @@ func TestRedis(t *testing.T) {
 }
 
 func TestRedisDo(t *testing.T) {
-	om := &OpenMock{}
+	om := &OpenMock{
+		RedisType: "",
+	}
 	r := redisDo(om)
 
 	t.Run("get non-exists", func(t *testing.T) {
@@ -57,5 +59,21 @@ func TestRedisDo(t *testing.T) {
 		r("SET", "hello", "456")
 		v := r("GET", "hello")
 		assert.Equal(t, "456", v)
+	})
+
+	t.Run("errors on template store args", func(t *testing.T) {
+		key := redisTemplatesStore + "_asdf123"
+		_, err := om.redis.Do("HSET", key, "123", "stuff")
+		if err != nil {
+			t.FailNow()
+		}
+
+		v := r("SET", key, "123", "things")
+		assert.Error(t, v.(error))
+
+		_, err = om.redis.Do("DEL", key)
+		if err != nil {
+			t.FailNow()
+		}
 	})
 }


### PR DESCRIPTION
Current

Openmock has an admin interface (HTTP on port 9998 by default) that allows user to POST new templates. Pseudo code: 

Unmarshal POST body as YAML into an open mock model (400 if fails) 
Foreach mock in loaded model
	S = marshal mock to YAML
	Redis hset redis_templates_storage <mock key> S
End
Restart OM process

When the OM (re)starts, it loads up YAML strings from the templates directory files, and from the redis key redis_templates_storage, and concatenates them into one big YAML string, which it then unmarshals into an OM model.  The redis stuff is loaded with `redis HGETALL redis_templates_storage`

The other functionality to note is that, when evaluating go templates in om (e.g. in conditions, http_reply bodies, etc), the `redisDo` commands lets mock users run arbitrary redis commands in the instance OM is using.  This could potentially interfere with the template storage database. 

What we’re trying to do 
We would like to add a new endpoint to post sets of templates.  This would allow remote services to functionally ‘delete’ the mocks that they’ve added, by doing HTTP DELETE at the same endpoint.  This is easier to implement than deleting each key of the mock since the job that does the empty post won’t have to parse the mocks or know anything about them, just the unique key used. 

Proposed
Add a new endpoint to the admin API to store sets of templates under a unique key (/api/v1/template_sets/:key). POSTing here causes om to save the mocks with `HSET (redis_templates_storage_<post key>) …`. DELETEing the same path that deletes the key redis_templates_storage_<post key>.  
When loading templates in load.go, first find all keys in the DB that start with redis_template_store, and concatenate the strings from all those hsets in the same way as we currently do with just redis_template_store.  This should load in all the mocks that were posted as a template set in addition to the base ones.

Testing
Added unit testing for new functionality. 
Manual test script: 
1. post a template with set-key ABC
2. post the same template with set-key DEF
3. GET the templates, observe the posted template was added
4. DELETE templates with set-key ABC
5. GET templates, observe the posted template still present
6. DELETE templates with set-key DEF
7. GET templates, observe the posted template is gone now that we've eliminated all sources of it

Work not directly related to immediate goal
Should we take this opportunity to define the admin IF with goswagger? 
If we do, we could also make part of `omctl update` use the generated client? 
It seems like a fair amount of work to define OM’s model in swagger terms and use it throughout, maybe save it for hack week projects
We should restrict the redisDo template helper so that any of the ‘args’ to the redis command are checked to see if they start with the string ‘redis_templates_storage’, and thow an error if so. This would prevent users from accidentally messing with OM’s template storage. 

Other solutions
Considered storing any additional post keys in a separate redis set so that we don’t have to use the KEYs command to find keys while loading.  KEYs is O(1) with a fairly low constant time on larger data stores, and we only have one redis instance for all of an IIE.  We should see if performance becomes a problem here, and if so implement that solution.  I don’t jump straight to it since it adds some complexity to the implementation in OM.
