### PR TITLE
Flush the HTTP response connection when doing reply_http action

### DIFF
--- a/demo_templates/webhook_example.yaml
+++ b/demo_templates/webhook_example.yaml
@@ -1,0 +1,60 @@
+# Simulate a webhook - it will reply_http immediately, but then later sends to 
+# a 'webhook' endpoint on the requesting service (also implemented in mock)
+#
+- key: webhook-post
+  kind: Behavior
+  expect:
+    http:
+      method: POST
+      path: /webhook
+  actions:
+    - reply_http:
+        status_code: 200
+        body: "Awesome!"
+    - sleep:
+        duration: 10s
+    - send_http:
+        url: http://localhost:9999/webhook-receive?param=1
+        method: POST
+    - sleep:
+        duration: 10s
+    - send_http:
+        url: http://localhost:9999/webhook-receive?param=2
+        method: POST
+
+# receive the webhook replies from the webhook-post mock and store them in redis
+#
+- key: webhook-receive
+  kind: Behavior
+  expect:
+    http:
+      method: POST
+      path: /webhook-receive
+  actions:
+    - redis:
+      - '{{ .HTTPQueryString | redisDo "RPUSH" "webhook-received" }}'
+
+# check the log of webhook posts received in redis
+#
+- key: webhook-received
+  kind: Behavior
+  expect:
+    http:
+      method: GET
+      path: /webhook
+  actions:
+    - reply_http:
+        status_code: 200
+        body: >
+          {
+            "received": [
+              {{ $arr := redisDo "LRANGE" "webhook-received" 0 -1 | splitList ";;" }}
+              {{ range $i, $v := $arr }}
+                {{if isLastIndex $i $arr}}
+                  "{{$v}}"
+                {{else}}
+                  "{{$v}}",
+                {{end}}
+              {{end}}
+            ]
+          }

--- a/handle_actions.go
+++ b/handle_actions.go
@@ -80,7 +80,7 @@ func (a ActionReplyHTTP) Perform(context Context) error {
 		return err
 	}
 
-	// finalize the HTTP response so that further actions don't effect our response
+	// finalize the HTTP response so that further actions make our response wait
 	ec.Response().Flush()
 	conn, _, err := ec.Response().Hijack()
 	if err != nil {

--- a/model.go
+++ b/model.go
@@ -49,6 +49,16 @@ func (m *Mock) Validate() error {
 		if len(m.Template) != 0 {
 			return fmt.Errorf("kind behavior is only permitted to have `key`, `expect` and `actions` fields. found in: %s", m.Key)
 		}
+
+		foundReply := false
+		for _, a := range m.Actions {
+			if !structs.IsZero(a.ActionReplyHTTP) {
+				if foundReply {
+					return fmt.Errorf("Only one reply_http action allowed per behavior")
+				}
+				foundReply = true
+			}
+		}
 	case KindAbstractBehavior:
 	default:
 		return fmt.Errorf(

--- a/model_test.go
+++ b/model_test.go
@@ -86,6 +86,27 @@ func TestModelValidate(t *testing.T) {
 		assert.Error(t, m.Validate())
 	})
 
+	t.Run("invalid KindBehavior - behavior cannot have multiple reply_http actions", func(t *testing.T) {
+		m := &Mock{
+			Key:      "t1",
+			Template: "t1",
+			Expect: Expect{
+				HTTP: ExpectHTTP{
+					Path: "/t1",
+				},
+			},
+			Actions: []ActionDispatcher{
+				{
+					ActionReplyHTTP: ActionReplyHTTP{StatusCode: 200, Body: "OK"},
+				},
+				{
+					ActionReplyHTTP: ActionReplyHTTP{StatusCode: 200, Body: "GREAT"},
+				},
+			},
+		}
+		assert.Error(t, m.Validate())
+	})
+
 	t.Run("invalid Kind", func(t *testing.T) {
 		m := &Mock{
 			Kind: "invalid",


### PR DESCRIPTION
See https://github.com/checkr/openmock/pull/55 for a write-up of the behavior we're trying to fix.  This change makes it so a `reply_http` action will flush the connection, sending the response to the requesting client, and then move on to running other actions defined by the `Behavior`.  

Also add validation to make sure that only one request_http is included per behavior (otherwise the connection would have been flushed when you try to run the second), and add a test for that validation.   Added an example in `demo_templates/webhook_example.yaml` of how to implement this kind of delayed webhook response. 