### PR TITLE
loadYAML always adds a new line

### DIFF
--- a/load.go
+++ b/load.go
@@ -172,6 +172,7 @@ func loadYAML(searchDir string) ([]byte, error) {
 				return err
 			}
 			w.Write(content)
+			w.Write([]byte("\n"))
 		}
 		return nil
 	})


### PR DESCRIPTION
- before this change, templating will fail if there is not a new line
charater at end of each yml file