### PR TITLE
Add template sets interactions to omctl CLI

### DIFF
--- a/cmd/omctl/cmd/delete.go
+++ b/cmd/omctl/cmd/delete.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete specified template set key on remote instance",
+	Long:  "delete specified template set key on remote instance",
+	Args:  cobra.MaximumNArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// check if remote instance reachable
+		response, httpErr := http.Get(openMockURL + "/api/v1/templates")
+		if httpErr != nil || response == nil {
+			return fmt.Errorf("Remote openmock instance not reachable %s: [%s]", openMockURL, httpErr)
+		}
+		if response.StatusCode != 200 {
+			return fmt.Errorf("Remote openmock instance not reachable %s: [%d]", openMockURL, response.StatusCode)
+		}
+		response.Body.Close()
+
+		// verify setKey was set
+		if setKey == "" {
+			return fmt.Errorf("Must use -k with delete")
+		}
+
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		httpPath := openMockURL + "/api/v1/template_sets/" + setKey
+
+		client := &http.Client{}
+		req, err := http.NewRequest("DELETE", httpPath, nil)
+		if err != nil {
+			logrus.Errorf("Error deleting templates at %s / %s: [%s]", openMockURL, setKey, err)
+			return err
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			logrus.Errorf("Error deleting templates at %s / %s: [%s]", openMockURL, setKey, err)
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 204 {
+			respBody, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				logrus.Errorf("Error deleting templates at %s / %s: [%s]", openMockURL, setKey, err)
+				return err
+			}
+			logrus.Errorf("Error deleting templates at %s / %s: [%s]", openMockURL, setKey, respBody)
+			return fmt.Errorf("")
+		}
+
+		logrus.Info("Deleted templates!")
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+}

--- a/cmd/omctl/cmd/root.go
+++ b/cmd/omctl/cmd/root.go
@@ -29,7 +29,11 @@ var localDirectory string
 // URL of remote openmock instance to control
 var openMockURL string
 
+// set key used when post / delete directory with a specific key
+var setKey string
+
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&localDirectory, "directory", "d", "./demo_templates", "Local directory in filesystem to upload to remote openmock")
 	RootCmd.PersistentFlags().StringVarP(&openMockURL, "url", "u", "http://localhost:9998", "URL for remote openmock instance to control")
+	RootCmd.PersistentFlags().StringVarP(&setKey, "set-key", "k", "", "'set' key to use when manipulating directory with a specific key")
 }

--- a/cmd/omctl/cmd/update.go
+++ b/cmd/omctl/cmd/update.go
@@ -42,9 +42,14 @@ var pushCmd = &cobra.Command{
 			return err
 		}
 
+		httpPath := "/api/v1/templates"
+		if setKey != "" {
+			httpPath = "/api/v1/template_sets/" + setKey
+		}
+
 		// post the loaded templates at the openmock instance
 		templatesYaml := localOpenMock.ToYAML()
-		response, httpErr := http.Post(openMockURL+"/api/v1/templates", "application/yaml", bytes.NewReader(templatesYaml))
+		response, httpErr := http.Post(openMockURL+httpPath, "application/yaml", bytes.NewReader(templatesYaml))
 		if httpErr != nil {
 			logrus.Errorf("Error posting templates at %s: [%s]", openMockURL, httpErr)
 			return httpErr

--- a/load.go
+++ b/load.go
@@ -81,8 +81,15 @@ func (om *OpenMock) populateBehaviors(mocks []*Mock) {
 			continue
 		}
 		if m.Extend != "" {
-			m = r.Behaviors[m.Extend].patchedWith(*m)
-			r.Behaviors[m.Key] = m
+			if r.Behaviors[m.Extend] == nil {
+				logrus.WithFields(logrus.Fields{
+					"name":   m.Key,
+					"extend": m.Extend,
+				}).Errorf("Mock %s attempt to extend unknown behavior %s", m.Key, m.Extend)
+			} else {
+				m = r.Behaviors[m.Extend].patchedWith(*m)
+				r.Behaviors[m.Key] = m
+			}
 		}
 		if !structs.IsZero(m.Expect.HTTP) {
 			_, ok := r.HTTPMocks[m.Expect.HTTP]


### PR DESCRIPTION
Add ability to interact with remote openmock instance's template_sets endpoint to omctl. 
* add `-k` param to let user specify set_key for commands
* adjust `push` command to hit `template_sets/:set_key` if `-k` is specified
* add `delete` command specifically working with `-k` to delete templates that were earlier pushed

Manual test plan: 
* spun up a local om `OPENMOCK_REDIS_TYPE=redis OPENMOCK_REDIS_URL=redis://localhost:6379 OPENMOCK_TEMPLATES_DIR=~/Documents/misc/templates ./om`
* posted demo templates at it `./omctl push -d demo_templates/ -k frank`
* GET http://localhost:9998/api/v1/templates to verify frank templates were posted 
* deleted demo templates `./omctl delete -k frank`
* GET http://localhost:9998/api/v1/templates again, verify frank templates no longer present

No unit tests changed; `make test` continues to complete successfully. 

Also added error handling in `load.go` so that if users attempt to extend a behavior that isn't currently in the model, it will log an error and not do the extension instead of seg faulting. 