### PR TITLE
Load body_from_file for ActionSendHTTP

### DIFF
--- a/load.go
+++ b/load.go
@@ -215,6 +215,13 @@ func (m *Mock) loadFile(baseDir string) {
 				h.BodyFromFile = ""
 			}
 		}
+		if !structs.IsZero(a.ActionSendHTTP) {
+			h := &a.ActionSendHTTP
+			if h.BodyFromFile != "" && h.Body == "" {
+				h.Body = readFile(m.Key, baseDir, h.BodyFromFile)
+				h.BodyFromFile = ""
+			}
+		}
 	}
 	logrus.Infof("template with key:%s loaded.", m.Key)
 }

--- a/load_test.go
+++ b/load_test.go
@@ -73,7 +73,7 @@ func TestLoadFile(t *testing.T) {
 		assert.NotZero(t, m.Actions[0].ActionPublishAMQP.Payload)
 	})
 
-	t.Run("http body", func(t *testing.T) {
+	t.Run("reply_http body", func(t *testing.T) {
 		m := &Mock{
 			Actions: []ActionDispatcher{
 				{
@@ -85,6 +85,20 @@ func TestLoadFile(t *testing.T) {
 		}
 		m.loadFile("demo_templates")
 		assert.NotZero(t, m.Actions[0].ActionReplyHTTP.Body)
+	})
+
+	t.Run("send_http body", func(t *testing.T) {
+		m := &Mock{
+			Actions: []ActionDispatcher{
+				{
+					ActionSendHTTP: ActionSendHTTP{
+						BodyFromFile: "./files/colors.json",
+					},
+				},
+			},
+		}
+		m.loadFile("demo_templates")
+		assert.NotZero(t, m.Actions[0].ActionSendHTTP.Body)
 	})
 
 	t.Run("file not found", func(t *testing.T) {


### PR DESCRIPTION
Currently if you want to perform `send_http` events with arbitrary data from a file (vs a kafka,ampq, or http payload) there is no way to do so since we do not do not replace the `ActionSendHTTP` `Body` field with the data in the file path located in the `BodyFromFile` field. We already do this for all other models with a `BodyFromFile` field.

Tested locally, looks good 👍 

test template looks like:
```
- key: ping
  kind: Behavior
  expect:
    http:
      method: GET
      path: /ping
  actions:
    - reply_http:
        status_code: 200
        body: OK
        headers:
          Content-Type: text/xml
    - sleep:
        duration: 10s
    - send_http:
        url: http://localhost:9999/hello
        method: POST
        body_from_file: ../files/test.tpl

- key: hello
  kind: Behavior
  expect:
    http:
      method: POST
      path: /hello
  actions:
    - reply_http:
        status_code: 200
        body: '{{ .HTTPBody }}'
```
and `test.tpl` is:
``` 
{
  "goodbye": "world"
}
```
running `curl http://localhost:9999/ping` we see the request to `/ping` return right away
<img width="725" alt="Screen Shot 2020-01-08 at 3 59 46 PM" src="https://user-images.githubusercontent.com/12383056/72026318-f3998e00-322f-11ea-814d-f9a7cff061b9.png">

then the request to `/hello` return with the body from the `test.tpl` file after 10 seconds:
<img width="715" alt="Screen Shot 2020-01-08 at 3 59 52 PM" src="https://user-images.githubusercontent.com/12383056/72026336-0613c780-3230-11ea-92cd-3107b7da2632.png">


