### PR TITLE
Add AbstractBehavior example value-with-numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Templates can be useful to assemble your payloads from parts
 Abstract Behaviors can be used to parameterize some data.
 
 When an abstract behavior and a behavior extending it both have actions defined, all of them are run when the behavior matches.  Actions will run from lowest to highest value of the 'order' field; if this is the same for two actions the action defined earlier in the abstract behavior runs first, followed by actions in the concrete behavior.
-Be aware that values with all digits will be interpreted into `int` type, and it will fail the condition check. Pipe to `toString` before the comparison or alternatively put quotes around the values. See example in `abstract_behaviors.yml`.
+Be aware that values with all digits will be interpreted into `int` type (YAML syntax), and it will fail the condition check given that some helper functions are returning `string` types. Pipe to `toString` before the comparison or alternatively put quotes around the values. See example in `abstract_behaviors.yml`.
 ```yaml
 - key: fruit-of-the-day
   kind: AbstractBehavior

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Templates can be useful to assemble your payloads from parts
 Abstract Behaviors can be used to parameterize some data.
 
 When an abstract behavior and a behavior extending it both have actions defined, all of them are run when the behavior matches.  Actions will run from lowest to highest value of the 'order' field; if this is the same for two actions the action defined earlier in the abstract behavior runs first, followed by actions in the concrete behavior.
+Be aware that values with all digits will be interpreted into `int` type, and it will fail the condition check. Pipe to `toString` before the comparison or alternatively put quotes around the values. See example in `abstract_behaviors.yml`.
 ```yaml
 - key: fruit-of-the-day
   kind: AbstractBehavior

--- a/demo_templates/abstract_behaviors.yml
+++ b/demo_templates/abstract_behaviors.yml
@@ -24,3 +24,33 @@
   extend: fruit-of-the-day
   values:
     day: tuesday
+
+#  Be aware that values with all digits will be interpreted into int type, and it will fail the condition check.
+#  Pipe to toString before the comparison (i.e. eq, contains, etc.) or alternatively put quotes around the values.
+- key: value-with-numbers
+  kind: AbstractBehavior
+  values:
+    count: 0
+  expect:
+    condition: '{{.HTTPQueryString | toString | eq .Values.count}}'
+    http:
+      method: GET
+      path: /value-with-numbers
+  actions:
+    - reply_http:
+        status_code: 200
+        body: '{"word": "{{.Values.word}}"}'
+
+- key: count-one
+  kind: Behavior
+  extend: value-with-numbers
+  values:
+    count: 1
+    word: one
+
+- key: count-two
+  kind: Behavior
+  extend: value-with-numbers
+  values:
+    count: 2
+    word: two


### PR DESCRIPTION
Add an `AbstractBehavior` example to address https://github.com/checkr/openmock/issues/70.