### PR TITLE
Add headers rendering and example of basicauth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unittest:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.14
     working_directory: /go/src/github.com/checkr/openmock
     steps:
       - checkout

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - golint
   disable:
     - maligned
+    - gocognit
   presets:
     - bugs
     - complexity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.14 as builder
 WORKDIR /go/src/github.com/checkr/openmock
 ADD . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ run: build
 lint:
 ifndef GOLANGCILINT
 	@GO111MODULE=off go get -u github.com/myitcv/gobin
-	@gobin github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+	@gobin github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 endif
 	@golangci-lint run
 

--- a/demo_templates/http.yaml
+++ b/demo_templates/http.yaml
@@ -193,3 +193,15 @@
     - reply_http:
         status_code: 200
         body: '{{ .HTTPBody | jsonPath "foo" }}'
+
+- key: base64-basicauth-with-env
+  kind: Behavior
+  expect:
+    http:
+      method: POST
+      path: /base64-basicauth-with-env
+  actions:
+    - reply_http:
+        headers:
+          Authorization: '{{ printf "foobar:%s" (env "BASIC_AUTH_PASS") | b64enc }}'
+        status_code: 200


### PR DESCRIPTION
Previously the headers in `reply_http` and `send_http` are not rendered with the context, this PR adds that so that headers can also be dynamic.

Example:
```
- key: base64-basicauth-with-env
  kind: Behavior
  expect:
    http:
      method: POST
      path: /base64-basicauth-with-env
  actions:
    - reply_http:
        headers:
          Authorization: '{{ printf "foobar:%s" (env "BASIC_AUTH_PASS") | b64enc }}'
        status_code: 200
```