### PR TITLE
Fix http path context and fix logging noise

### DIFF
--- a/handle_actions.go
+++ b/handle_actions.go
@@ -50,6 +50,7 @@ func (a ActionSendHTTP) Perform(ctx Context) error {
 	}
 
 	request := gorequest.New().
+		SetDebug(true).
 		SetLogger(newOmLogger(ctx)).
 		CustomMethod(a.Method, urlStr)
 

--- a/http.go
+++ b/http.go
@@ -42,7 +42,7 @@ func (om *OpenMock) startHTTP() {
 						HTTPContext:     ec,
 						HTTPHeader:      ec.Request().Header,
 						HTTPBody:        string(body),
-						HTTPPath:        ec.Path(),
+						HTTPPath:        ec.Request().URL.String(),
 						HTTPQueryString: ec.QueryString(),
 						om:              om,
 					}

--- a/openmock.go
+++ b/openmock.go
@@ -2,7 +2,6 @@ package openmock
 
 import (
 	"log"
-	"os"
 
 	"github.com/caarlos0/env"
 	"github.com/goombaio/orderedmap"
@@ -82,8 +81,7 @@ func (om *OpenMock) SetupLogrus() {
 		logrus.WithField("err", err).Fatalf("failed to set logrus level:%s", om.LogLevel)
 	}
 	logrus.SetLevel(l)
-	logrus.SetOutput(os.Stdout)
-	logrus.SetReportCaller(true)
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 }
 
 func (om *OpenMock) SetupRepo() {
@@ -101,7 +99,6 @@ func (om *OpenMock) SetupRepo() {
 func (om *OpenMock) Start() {
 	om.SetupLogrus()
 	om.SetupRepo()
-
 	om.SetRedis()
 
 	err := om.Load()


### PR DESCRIPTION
- Fixed .HTTPPath. It was set as `ec.Path()` which doesn't render path params. For example, path `/report/:id` will be literal in echo's Path() function. We should render the path with its actual runtime value
- Reduce the logging noise by removing `logrus.SetReportCaller(true)`
- Adding `SetDebug(true)` for send_http actions